### PR TITLE
Use show page as survey detail page

### DIFF
--- a/config/admin/admin.go
+++ b/config/admin/admin.go
@@ -48,4 +48,5 @@ func init() {
 	// Add Survey
 	survey := Admin.AddResource(&models.Survey{}, &admin.Config{Permission: roles.Deny(roles.Create, roles.Anyone).Deny(roles.Update, roles.Anyone)})
 	survey.IndexAttrs("ID", "Interviewer", "Age", "Gender", "Postcode", "Email", "Mobile")
+	survey.ShowAttrs("-UpdatedAt")
 }


### PR DESCRIPTION
There's only create and update permissions for survey resource in admin.

But Qor still uses the edit page as survey's detail page by default, we need to config `ShowAttrs` to let admin display the show page when to click a survey.

Read more detail:
https://qortex.com/theplant/#groups/52156d1a3c58162268002cea/entry/56e906028d93e3419713494c
