### PR TITLE
Fix data race issues that caused by airbraker's buffer notifier

### DIFF
--- a/app/controllers/controllers_test.go
+++ b/app/controllers/controllers_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	au "github.com/theplant/airbraker/utils"
 	"github.com/theplant/hsm-acem-survey-app/config/routes"
 
 	// Ensure DB is reset
@@ -15,18 +16,23 @@ import (
 )
 
 var (
-	mux    *http.ServeMux
-	server *httptest.Server
+	mux      *http.ServeMux
+	server   *httptest.Server
+	notifier *au.BufferNotifier
 )
 
 func init() {
 	mux = routes.Mux()
 }
 
-// TestMain sets up a clean database and create a new server instance
-// for every test case. It also close the server after done the test case.
+// TestMain sets up a clean database, create a new server
+// instance and a buffer notifier for every test case.
+//
+// It also close the server after done the test case.
 func TestMain(m *testing.M) {
 	server = httptest.NewServer(mux)
+	// skip the default value of airbraker.Airbrake here
+	notifier, _ = au.NewBufferNotifier()
 
 	retCode := m.Run()
 

--- a/app/controllers/surveys_test.go
+++ b/app/controllers/surveys_test.go
@@ -145,9 +145,6 @@ func TestSendEmailInvalidParams(t *testing.T) {
 
 func TestSendEmailFailingMandrill(t *testing.T) {
 	mu.ErrorMandrillConfigure()
-
-	notifier, airbrake := au.NewBufferNotifier()
-	defer au.SetNotifier(airbrake)
 	au.ClearBuffer(notifier)
 
 	req := prepareEmailRequest(t, emailParams())
@@ -202,9 +199,6 @@ func TestSendFeedbackMailInvalidParams(t *testing.T) {
 
 func TestSendFeedbackMailFailingMandrill(t *testing.T) {
 	mu.ErrorMandrillConfigure()
-
-	notifier, airbrake := au.NewBufferNotifier()
-	defer au.SetNotifier(airbrake)
 	au.ClearBuffer(notifier)
 
 	req := prepareFeedbackRequest(t, feedbackMailParams())


### PR DESCRIPTION
- Refactor to make buffer notifier as global variable in controller test
- Fix data race issues #74

Note: this requires [merge the PR in airbraker](https://github.com/theplant/airbraker/pull/1).
